### PR TITLE
dateparser: changed return type and implemented fromstr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
 name = "dateparser"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,3 @@
-# [package]
-# name = "belt"
-# version = "0.1.0"
-# authors = ["Rollie Ma <rollie@rollie.dev>"]
-# edition = "2018"
-# publish = false
-# description = "Know your time from a list of selected time zones"
-#
-# [dependencies]
-# anyhow = "1.0.40"
-# chrono = "0.4"
-# chrono-tz = "0.5"
-# clap = "3.0.0-beta.2"
-# colored = "2.0.0"
-# confy = "0.4.0"
-# directories = "^2.0"
-# prettytable-rs = "0.8.0"
-# regex = "1.5.4"
-# serde = { version = "1.0.125", features = ["derive"] }
-
 [workspace]
 members = [
     "belt",

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+.PHONY: build
+build:
+	cargo build --release
+
+.PHONY: lint
+lint:
+	cargo clippy --workspace --tests --all-features -- -D warnings
+
+.PHONY: test
+test:
+	cargo test
+
+.PHONY: cover
+cover:
+	docker run \
+        --security-opt seccomp=unconfined \
+        -v ${PWD}:/volume \
+        xd009642/tarpaulin \
+        cargo tarpaulin --out Html --output-dir ./target
+	open target/tarpaulin-report.html
+
+.PHONY: cross
+cross: build
+	docker build -t $(APP)/cross -f cross.Dockerfile .
+	docker run -it --rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v $$PWD:/src/$(APP) \
+		-w /src/$(APP) \
+		$(APP)/cross \
+		/bin/bash -c ' \
+			cross build --target x86_64-unknown-linux-gnu --release && \
+			cross build --target x86_64-unknown-linux-musl --release && \
+			cross build --target armv7-unknown-linux-gnueabihf --release \
+		'
+
+APP = belt
+VERSION := $(shell cargo metadata -q | jq -r '.packages[] | select(.name == "$(APP)") | .version')
+MACOS_X86_64 := target/package/$(APP)-$(VERSION)-x86_64-apple-darwin.zip
+LINUX_DYN_X86_64 := target/package/$(APP)-$(VERSION)-x86_64-unknown-linux-gnu.tar.gz
+LINUX_STAT_X86_64 := target/package/$(APP)-$(VERSION)-x86_64-unknown-linux-musl.tar.gz
+LINUX_ARMV7 := target/package/$(APP)-$(VERSION)-armv7-unknown-linux-gnueabihf.tar.gz
+
+.PHONY: release
+release: cross
+	@echo "[release] Cleaning up before packaging..."
+	mkdir -p target/package
+	rm -f $(MACOS_X86_64) $(LINUX_X86_64) $(LINUX_ARMV7)
+	@echo "[release] Creating package for MacOS x86_64..."
+	zip -j $(MACOS_X86_64) target/release/$(APP) LICENSE README.md
+	@echo "[release] Creating package for Linux (dynamic) x86_64..."
+	tar -cvzf $(LINUX_DYN_X86_64) \
+		-C $$PWD/target/x86_64-unknown-linux-gnu/release $(APP) \
+		-C $$PWD LICENSE README.md
+	@echo "[release] Creating package for Linux (static) x86_64..."
+	tar -cvzf $(LINUX_STAT_X86_64) \
+		-C $$PWD/target/x86_64-unknown-linux-musl/release $(APP) \
+		-C $$PWD LICENSE README.md
+	@echo "[release] Creating package for Linux armv7..."
+	tar -cvzf $(LINUX_ARMV7) \
+		-C $$PWD/target/armv7-unknown-linux-gnueabihf/release $(APP) \
+		-C $$PWD LICENSE README.md

--- a/belt/Cargo.toml
+++ b/belt/Cargo.toml
@@ -13,7 +13,7 @@ chrono-tz = "0.5"
 clap = "3.0.0-beta.2"
 colored = "2.0.0"
 confy = "0.4.0"
+dateparser = { path = "../dateparser" }
 directories = "^2.0"
 prettytable-rs = "0.8.0"
 serde = { version = "1.0.125", features = ["derive"] }
-dateparser = { path = "../dateparser" }

--- a/belt/src/app.rs
+++ b/belt/src/app.rs
@@ -6,7 +6,7 @@ use anyhow::{Error, Result};
 use chrono::prelude::*;
 use chrono_tz::Tz;
 use colored::*;
-use dateparser::parse;
+use dateparser::DateTimeUtc;
 use prettytable::{cell, row, Table};
 
 pub struct App<'a> {
@@ -21,16 +21,15 @@ impl<'a> App<'a> {
 
     pub fn show_datetime(&self) -> Result<()> {
         if self.opts.subcommands.is_some() {
-            // is subcommands are given, skip showing datetime
+            // skip showing datetime: subcommand given,
+            // and it will be handle in another method
             return Ok(());
         }
 
-        let to_show = &self
-            .opts
-            .time
-            .as_ref()
-            .and_then(|time| parse(&time)) // if datetime given in args, try to parse it
-            .unwrap_or_else(|| Utc::now()); // no datetime given or could not parse it, fall back on now @ utc
+        let mut to_show = Utc::now();
+        if let Some(time) = &self.opts.time {
+            to_show = time.parse::<DateTimeUtc>()?.0;
+        }
 
         let mut table = Table::new();
         let local = to_show.with_timezone(&Local);

--- a/cross.Dockerfile
+++ b/cross.Dockerfile
@@ -1,0 +1,23 @@
+FROM rust:1.50.0-buster
+
+ENV CROSS_DOCKER_IN_DOCKER=true
+RUN cargo install cross
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+RUN echo \
+  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io

--- a/dateparser/Cargo.toml
+++ b/dateparser/Cargo.toml
@@ -2,8 +2,15 @@
 name = "dateparser"
 version = "0.1.0"
 authors = ["Rollie Ma <rollie@rollie.dev>"]
+description = "Parse dates in string formats that are commonly used."
+readme = "README.md"
+homepage = "https://github.com/waltzofpearls/belt/tree/main/dateparser"
+repository = "https://github.com/waltzofpearls/belt/tree/main/dateparser"
+keywords = ["date", "time", "datetime", "parser", "parse"]
+license = "MIT"
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.40"
 chrono = "0.4"
 regex = "1.5.4"

--- a/dateparser/src/lib.rs
+++ b/dateparser/src/lib.rs
@@ -1,7 +1,18 @@
+use anyhow::{anyhow, Error, Result};
 use chrono::prelude::*;
 use regex::Regex;
 
-pub fn parse(input: &str) -> Option<DateTime<Utc>> {
+pub struct DateTimeUtc(pub DateTime<Utc>);
+
+impl std::str::FromStr for DateTimeUtc {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        parse(s).map(|dt| DateTimeUtc(dt))
+    }
+}
+
+pub fn parse(input: &str) -> Result<DateTime<Utc>> {
     parse_unix_timestamp(input)
         .or_else(|| parse_unix_timestamp_millis(input))
         .or_else(|| parse_unix_timestamp_nanos(input))
@@ -16,97 +27,121 @@ pub fn parse(input: &str) -> Option<DateTime<Utc>> {
         .or_else(|| parse_ymd_z(input))
         .or_else(|| parse_hms_imp(input))
         .or_else(|| parse_hms_imp_z(input))
+        .unwrap_or_else(|| Err(anyhow!("{} did not match any formats.", input)))
 }
 
 // 1511648546
-fn parse_unix_timestamp(input: &str) -> Option<DateTime<Utc>> {
-    let re = Regex::new(r"^[0-9]{10}$").unwrap();
-    if re.is_match(input) {
-        return input
-            .parse::<i64>()
-            .ok()
-            .map(|timestamp| Utc.timestamp(timestamp, 0).with_timezone(&Utc));
+fn parse_unix_timestamp(input: &str) -> Option<Result<DateTime<Utc>>> {
+    match Regex::new(r"^[0-9]{10}$").map_err(Error::msg) {
+        Ok(re) => {
+            if re.is_match(input) {
+                return input
+                    .parse::<i64>()
+                    .ok()
+                    .map(|timestamp| Utc.timestamp(timestamp, 0).with_timezone(&Utc))
+                    .map(Ok);
+            }
+            None
+        }
+        Err(err) => Some(Err(err)),
     }
-    None
 }
 
 // 1620021848429
-fn parse_unix_timestamp_millis(input: &str) -> Option<DateTime<Utc>> {
-    let re = Regex::new(r"^[0-9]{13}$").unwrap();
-    if re.is_match(input) {
-        return input
-            .parse::<i64>()
-            .ok()
-            .map(|timestamp| Utc.timestamp_millis(timestamp).with_timezone(&Utc));
+fn parse_unix_timestamp_millis(input: &str) -> Option<Result<DateTime<Utc>>> {
+    match Regex::new(r"^[0-9]{13}$").map_err(Error::msg) {
+        Ok(re) => {
+            if re.is_match(input) {
+                return input
+                    .parse::<i64>()
+                    .ok()
+                    .map(|timestamp| Utc.timestamp_millis(timestamp).with_timezone(&Utc))
+                    .map(Ok);
+            }
+            None
+        }
+        Err(err) => Some(Err(err)),
     }
-    None
 }
 
 // 1620024872717915000
-fn parse_unix_timestamp_nanos(input: &str) -> Option<DateTime<Utc>> {
-    let re = Regex::new(r"^[0-9]{19}$").unwrap();
-    if re.is_match(input) {
-        return input
-            .parse::<i64>()
-            .ok()
-            .map(|timestamp| Utc.timestamp_nanos(timestamp).with_timezone(&Utc));
+fn parse_unix_timestamp_nanos(input: &str) -> Option<Result<DateTime<Utc>>> {
+    match Regex::new(r"^[0-9]{19}$").map_err(Error::msg) {
+        Ok(re) => {
+            if re.is_match(input) {
+                return input
+                    .parse::<i64>()
+                    .ok()
+                    .map(|timestamp| Utc.timestamp_nanos(timestamp).with_timezone(&Utc))
+                    .map(Ok);
+            }
+            None
+        }
+        Err(err) => Some(Err(err)),
     }
-    None
 }
 
 // 2021-05-01T01:17:02.604456Z
 // 2017-11-25T22:34:50Z
-fn parse_rfc3339(input: &str) -> Option<DateTime<Utc>> {
+fn parse_rfc3339(input: &str) -> Option<Result<DateTime<Utc>>> {
     DateTime::parse_from_rfc3339(input)
         .ok()
         .map(|parsed| parsed.with_timezone(&Utc))
+        .map(Ok)
 }
 
 // Wed, 02 Jun 2021 06:31:39 GMT
-fn parse_rfc2822(input: &str) -> Option<DateTime<Utc>> {
+fn parse_rfc2822(input: &str) -> Option<Result<DateTime<Utc>>> {
     DateTime::parse_from_rfc2822(input)
         .ok()
         .map(|parsed| parsed.with_timezone(&Utc))
+        .map(Ok)
 }
 
 // 2019-11-29 08:08:05-08
-fn parse_postgres_timestamp(input: &str) -> Option<DateTime<Utc>> {
+fn parse_postgres_timestamp(input: &str) -> Option<Result<DateTime<Utc>>> {
     DateTime::parse_from_str(input, "%Y-%m-%d %H:%M:%S%#z")
         .ok()
         .map(|parsed| parsed.with_timezone(&Utc))
+        .map(Ok)
 }
 
 // 2021-05-02 23:31:36.0741-07
 // 2021-05-02 23:31:39.12689-07
 // 2019-11-29 08:15:47.624504-08
-fn parse_postgres_timestamp_nanos(input: &str) -> Option<DateTime<Utc>> {
+fn parse_postgres_timestamp_nanos(input: &str) -> Option<Result<DateTime<Utc>>> {
     DateTime::parse_from_str(input, "%Y-%m-%d %H:%M:%S.%f%#z")
         .ok()
         .map(|parsed| parsed.with_timezone(&Utc))
+        .map(Ok)
 }
 
 // 2021-04-30 21:14:10
-fn parse_ymd_hms(input: &str) -> Option<DateTime<Utc>> {
+fn parse_ymd_hms(input: &str) -> Option<Result<DateTime<Utc>>> {
     Local
         .datetime_from_str(input, "%Y-%m-%d %H:%M:%S")
         .ok()
         .map(|parsed| parsed.with_timezone(&Utc))
+        .map(Ok)
 }
 
 // 2021-04-30 21:14:10.052282
-fn parse_ymd_hms_nanos(input: &str) -> Option<DateTime<Utc>> {
+fn parse_ymd_hms_nanos(input: &str) -> Option<Result<DateTime<Utc>>> {
     Local
         .datetime_from_str(input, "%Y-%m-%d %H:%M:%S.%f")
         .ok()
         .map(|parsed| parsed.with_timezone(&Utc))
+        .map(Ok)
 }
 
 // 2017-11-25 13:31:15 PST
 // 2017-11-25 13:31 PST
-fn parse_ymd_hms_hm_z(input: &str) -> Option<DateTime<Utc>> {
-    let re =
-        Regex::new(r"^(?P<dt>[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}(:[0-9]{2})?)\s+(?P<tz>[a-zA-Z0-9]{3,4})$").unwrap();
-    if let Some(caps) = re.captures(input) {
+fn parse_ymd_hms_hm_z(input: &str) -> Option<Result<DateTime<Utc>>> {
+    match Regex::new(
+        r"^(?P<dt>[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}(:[0-9]{2})?)\s+(?P<tz>[a-zA-Z0-9]{3,4})$",
+    ).map_err(Error::msg) {
+    Ok(re) => {
+        if let Some(caps) = re.captures(input) {
         if let Some(matched_dt) = caps.name("dt") {
             if let Some(matched_tz) = caps.name("tz") {
                 return NaiveDateTime::parse_from_str(matched_dt.as_str(), "%Y-%m-%d %H:%M:%S")
@@ -123,96 +158,112 @@ fn parse_ymd_hms_hm_z(input: &str) -> Option<DateTime<Utc>> {
                         )
                         .ok()
                     })
-                    .map(|datetime| datetime.with_timezone(&Utc));
+                    .map(|datetime| datetime.with_timezone(&Utc))
+                    .map(Ok)
             }
         }
     }
     None
+    }
+    Err(err) => Some(Err(err)),
+    }
 }
 
 // 2021-02-21
-fn parse_ymd(input: &str) -> Option<DateTime<Utc>> {
+fn parse_ymd(input: &str) -> Option<Result<DateTime<Utc>>> {
     NaiveDate::parse_from_str(input, "%Y-%m-%d")
         .ok()
         .map(|parsed| parsed.and_time(Local::now().time()))
         .and_then(|datetime| Local.from_local_datetime(&datetime).single())
         .map(|local| local.with_timezone(&Utc))
+        .map(Ok)
 }
 
 // 2021-02-21 PST
-fn parse_ymd_z(input: &str) -> Option<DateTime<Utc>> {
-    let re =
-        Regex::new(r"^(?P<date>[0-9]{4}-[0-9]{2}-[0-9]{2})\s+(?P<tz>[a-zA-Z0-9]{3,4})$").unwrap();
-    if let Some(caps) = re.captures(input) {
-        if let Some(matched_date) = caps.name("date") {
-            if let Some(matched_tz) = caps.name("tz") {
-                return NaiveDate::parse_from_str(matched_date.as_str(), "%Y-%m-%d")
-                    .ok()
-                    .and_then(|parsed| {
-                        DateTime::parse_from_rfc2822(
-                            (parsed
-                                .and_time(Local::now().time())
-                                .format("%a, %d %b %Y %H:%M:%S")
-                                .to_string()
-                                + " "
-                                + tz_2822(matched_tz.as_str()).as_ref())
-                            .as_ref(),
-                        )
-                        .ok()
-                    })
-                    .map(|datetime| datetime.with_timezone(&Utc));
+fn parse_ymd_z(input: &str) -> Option<Result<DateTime<Utc>>> {
+    match Regex::new(r"^(?P<date>[0-9]{4}-[0-9]{2}-[0-9]{2})\s+(?P<tz>[a-zA-Z0-9]{3,4})$")
+        .map_err(Error::msg)
+    {
+        Ok(re) => {
+            if let Some(caps) = re.captures(input) {
+                if let Some(matched_date) = caps.name("date") {
+                    if let Some(matched_tz) = caps.name("tz") {
+                        return NaiveDate::parse_from_str(matched_date.as_str(), "%Y-%m-%d")
+                            .ok()
+                            .and_then(|parsed| {
+                                DateTime::parse_from_rfc2822(
+                                    (parsed
+                                        .and_time(Local::now().time())
+                                        .format("%a, %d %b %Y %H:%M:%S")
+                                        .to_string()
+                                        + " "
+                                        + tz_2822(matched_tz.as_str()).as_ref())
+                                    .as_ref(),
+                                )
+                                .ok()
+                            })
+                            .map(|datetime| datetime.with_timezone(&Utc))
+                            .map(Ok);
+                    }
+                }
             }
+            None
         }
+        Err(err) => Some(Err(err)),
     }
-    None
 }
 
 // 01:06:06
 // 4:00pm
 // 6:00 AM
-fn parse_hms_imp(input: &str) -> Option<DateTime<Utc>> {
+fn parse_hms_imp(input: &str) -> Option<Result<DateTime<Utc>>> {
     NaiveTime::parse_from_str(input, "%H:%M:%S")
         .or_else(|_| NaiveTime::parse_from_str(input, "%I:%M%P"))
         .or_else(|_| NaiveTime::parse_from_str(input, "%I:%M %P"))
         .ok()
         .and_then(|parsed| Local::now().date().and_time(parsed))
         .map(|datetime| datetime.with_timezone(&Utc))
+        .map(Ok)
 }
 
 // 01:06:06 PST
 // 4:00pm PST
 // 6:00 AM PST
-fn parse_hms_imp_z(input: &str) -> Option<DateTime<Utc>> {
-    let re = Regex::new(
+fn parse_hms_imp_z(input: &str) -> Option<Result<DateTime<Utc>>> {
+    match Regex::new(
         r"^(?P<time>[0-9]{1,2}:[0-9]{2}(:[0-9]{2})?(\s*(am|pm|AM|PM)?))\s+(?P<tz>[a-zA-Z0-9]{3,4})$",
-    )
-    .unwrap();
-    if let Some(caps) = re.captures(input) {
-        if let Some(matched_time) = caps.name("time") {
-            if let Some(matched_tz) = caps.name("tz") {
-                return NaiveTime::parse_from_str(matched_time.as_str(), "%H:%M:%S")
-                    .or_else(|_| NaiveTime::parse_from_str(matched_time.as_str(), "%I:%M%P"))
-                    .or_else(|_| NaiveTime::parse_from_str(matched_time.as_str(), "%I:%M %P"))
-                    .ok()
-                    .and_then(|parsed| {
-                        DateTime::parse_from_rfc2822(
-                            (Local::now()
-                                .date()
-                                .naive_local()
-                                .and_time(parsed)
-                                .format("%a, %d %b %Y %H:%M:%S")
-                                .to_string()
-                                + " "
-                                + tz_2822(matched_tz.as_str()).as_ref())
-                            .as_ref(),
-                        )
-                        .ok()
-                    })
-                    .map(|datetime| datetime.with_timezone(&Utc));
+    ).map_err(Error::msg) {
+        Ok(re) => {
+            if let Some(caps) = re.captures(input) {
+                if let Some(matched_time) = caps.name("time") {
+                    if let Some(matched_tz) = caps.name("tz") {
+                        return NaiveTime::parse_from_str(matched_time.as_str(), "%H:%M:%S")
+                            .or_else(|_| NaiveTime::parse_from_str(matched_time.as_str(), "%I:%M%P"))
+                            .or_else(|_| NaiveTime::parse_from_str(matched_time.as_str(), "%I:%M %P"))
+                            .ok()
+                            .and_then(|parsed| {
+                                DateTime::parse_from_rfc2822(
+                                    (Local::now()
+                                        .date()
+                                        .naive_local()
+                                        .and_time(parsed)
+                                        .format("%a, %d %b %Y %H:%M:%S")
+                                        .to_string()
+                                        + " "
+                                        + tz_2822(matched_tz.as_str()).as_ref())
+                                    .as_ref(),
+                                )
+                                .ok()
+                            })
+                            .map(|datetime| datetime.with_timezone(&Utc))
+                            .map(Ok);
+                    }
+                }
             }
-        }
+            None
+        },
+        Err(err) => Some(Err(err)),
     }
-    None
 }
 
 fn tz_2822(tz: &str) -> String {


### PR DESCRIPTION
- return type for parse() function changed from Option<DateTime<Utc>> to
  Result<DateTime<Utc>>, error that has to bubble up will be returned,
  for example, regex parsing error or no matching format to parse input
  date str
- newtype DateTimeUtc(DateTime<Utc>) and implemented FromStr for
  DateTimeUtc, so in addition to calling parse(input),
  input.parse::<DateTimeUrc>() works too