### PR TITLE
dateparser: add `parse_with()` for configurable tz and default time

### DIFF
--- a/belt/src/app.rs
+++ b/belt/src/app.rs
@@ -73,10 +73,10 @@ where
                         self.config.reset()?;
                         self.config.list()?;
                     } else if let Some(add) = &c.add {
-                        self.config.add(&add)?;
+                        self.config.add(add)?;
                         self.config.list()?;
                     } else if let Some(delete) = &c.delete {
-                        self.config.delete(&delete)?;
+                        self.config.delete(delete)?;
                         self.config.list()?;
                     }
                 }
@@ -118,8 +118,7 @@ mod tests {
         }
         let re = Regex::new(r"[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} [0-9-+]{5}")
             .expect("failed to parse regex");
-        let matches: Vec<&str> = re.find_iter(&printed).map(|mat| mat.as_str()).collect();
-        assert_eq!(matches.len(), num_timezones + 1); // num_timezones + local
+        assert_eq!(re.find_iter(&printed).count(), num_timezones + 1); // num_timezones + local
     }
 
     #[test]


### PR DESCRIPTION
a date string without time (eg. `July 14, 2021`) can be parsed into
DateTime<Utc> assigned with local time or midnight at UTC, for example,
either `2021-07-14T22:51:35.983216400Z` or `2021-07-14T00:00:00Z`.

Resolves https://github.com/waltzofpearls/belt/issues/16