### PR TITLE
`#[derive(Clone, Debug)]` for `DateTimeUtc`

### DIFF
--- a/dateparser/src/lib.rs
+++ b/dateparser/src/lib.rs
@@ -249,6 +249,7 @@ use chrono::prelude::*;
 ///     Err(err) => println!("ERROR from parsing datetime string: {}", err)
 /// }
 /// ```
+#[derive(Clone, Debug)]
 pub struct DateTimeUtc(pub DateTime<Utc>);
 
 impl std::str::FromStr for DateTimeUtc {


### PR DESCRIPTION
This `#[derive(Clone, Debug)]`s for `DateTimeUtc`.  This allows it be used with `clap`, for example, as it requires a `Clone` and `Debug` `impl`.  It's also just generally useful, since the wrapped `DateTime<Utc>` implements these traits anyways.