### PR TITLE
Fix parse_with()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,14 +146,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -218,6 +235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +271,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "criterion"
@@ -346,6 +379,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e599641dff337570f6aa9c304ecca92341d30bf72e1c50287869ed6a36615a6"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e2434bc22249c056e12d2e87db46380730da0f2648471edea3e8e11834a892"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3894ad0c6d517cb5a4ce8ec20b37cd0ea31b480fe582a104c5db67ae21270853"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fa7e395dc1c001083c7eed28c8f0f0b5a225610f3b6284675f444af6fab86b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -457,6 +534,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,9 +599,18 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "log"
@@ -554,6 +664,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -864,6 +980,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "serde"

--- a/dateparser/Cargo.toml
+++ b/dateparser/Cargo.toml
@@ -8,11 +8,11 @@ homepage = "https://github.com/waltzofpearls/belt/tree/main/dateparser"
 repository = "https://github.com/waltzofpearls/belt/tree/main/dateparser"
 keywords = ["date", "time", "datetime", "parser", "parse"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.40"
-chrono = "0.4"
+chrono = "0.4.24"
 lazy_static = "1.4.0"
 regex = "1.6.0"
 

--- a/dateparser/src/datetime.rs
+++ b/dateparser/src/datetime.rs
@@ -269,10 +269,9 @@ where
         }
 
         // set time to use
-        let time = if let Some(v) = self.default_time {
-            v
-        } else {
-            Utc::now().with_timezone(self.tz).time()
+        let time = match self.default_time {
+            Some(v) => v,
+            None => Utc::now().with_timezone(self.tz).time(),
         };
 
         NaiveDate::parse_from_str(input, "%Y-%m-%d")
@@ -301,10 +300,9 @@ where
                 return match timezone::parse(matched_tz.as_str().trim()) {
                     Ok(offset) => {
                         // set time to use
-                        let time = if let Some(v) = self.default_time {
-                            v
-                        } else {
-                            Utc::now().with_timezone(&offset).time()
+                        let time = match self.default_time {
+                            Some(v) => v,
+                            None => Utc::now().with_timezone(&offset).time(),
                         };
                         NaiveDate::parse_from_str(input, "%Y-%m-%d %Z")
                             .ok()
@@ -393,10 +391,9 @@ where
         }
 
         // set time to use
-        let time = if let Some(v) = self.default_time {
-            v
-        } else {
-            Utc::now().with_timezone(self.tz).time()
+        let time = match self.default_time {
+            Some(v) => v,
+            None => Utc::now().with_timezone(self.tz).time(),
         };
 
         NaiveDate::parse_from_str(input, "%Y-%m-%d")
@@ -511,10 +508,9 @@ where
         }
 
         // set time to use
-        let time = if let Some(v) = self.default_time {
-            v
-        } else {
-            Utc::now().with_timezone(self.tz).time()
+        let time = match self.default_time {
+            Some(v) => v,
+            None => Utc::now().with_timezone(self.tz).time(),
         };
 
         let dt = input.replace(", ", " ").replace(". ", " ");
@@ -568,10 +564,9 @@ where
         }
 
         // set time to use
-        let time = if let Some(v) = self.default_time {
-            v
-        } else {
-            Utc::now().with_timezone(self.tz).time()
+        let time = match self.default_time {
+            Some(v) => v,
+            None => Utc::now().with_timezone(self.tz).time(),
         };
 
         NaiveDate::parse_from_str(input, "%d %B %y")
@@ -637,10 +632,9 @@ where
         }
 
         // set time to use
-        let time = if let Some(v) = self.default_time {
-            v
-        } else {
-            Utc::now().with_timezone(self.tz).time()
+        let time = match self.default_time {
+            Some(v) => v,
+            None => Utc::now().with_timezone(self.tz).time(),
         };
 
         NaiveDate::parse_from_str(input, "%m/%d/%y")
@@ -693,10 +687,9 @@ where
         }
 
         // set time to use
-        let time = if let Some(v) = self.default_time {
-            v
-        } else {
-            Utc::now().with_timezone(self.tz).time()
+        let time = match self.default_time {
+            Some(v) => v,
+            None => Utc::now().with_timezone(self.tz).time(),
         };
 
         NaiveDate::parse_from_str(input, "%Y/%m/%d")
@@ -723,10 +716,9 @@ where
         }
 
         // set time to use
-        let time = if let Some(v) = self.default_time {
-            v
-        } else {
-            Utc::now().with_timezone(self.tz).time()
+        let time = match self.default_time {
+            Some(v) => v,
+            None => Utc::now().with_timezone(self.tz).time(),
         };
 
         NaiveDate::parse_from_str(input, "%m.%d.%y")
@@ -789,10 +781,9 @@ where
         }
 
         // set time to use
-        let time = if let Some(v) = self.default_time {
-            v
-        } else {
-            Utc::now().with_timezone(self.tz).time()
+        let time = match self.default_time {
+            Some(v) => v,
+            None => Utc::now().with_timezone(self.tz).time(),
         };
 
         NaiveDate::parse_from_str(input, "%Y年%m月%d日")

--- a/dateparser/src/datetime.rs
+++ b/dateparser/src/datetime.rs
@@ -272,11 +272,7 @@ where
         let time = if let Some(v) = self.default_time {
             v
         } else {
-            Utc::now()
-                .date()
-                .and_time(Utc::now().time())?
-                .with_timezone(self.tz)
-                .time()
+            Utc::now().with_timezone(self.tz).time()
         };
 
         NaiveDate::parse_from_str(input, "%Y-%m-%d")
@@ -308,11 +304,7 @@ where
                         let time = if let Some(v) = self.default_time {
                             Utc::now().date().and_time(v)?.with_timezone(&offset).time()
                         } else {
-                            Utc::now()
-                                .date()
-                                .and_time(Utc::now().time())?
-                                .with_timezone(&offset)
-                                .time()
+                            Utc::now().with_timezone(&offset).time()
                         };
                         NaiveDate::parse_from_str(input, "%Y-%m-%d %Z")
                             .ok()
@@ -404,11 +396,7 @@ where
         let time = if let Some(v) = self.default_time {
             v
         } else {
-            Utc::now()
-                .date()
-                .and_time(Utc::now().time())?
-                .with_timezone(self.tz)
-                .time()
+            Utc::now().with_timezone(self.tz).time()
         };
 
         NaiveDate::parse_from_str(input, "%Y-%m-%d")
@@ -526,11 +514,7 @@ where
         let time = if let Some(v) = self.default_time {
             v
         } else {
-            Utc::now()
-                .date()
-                .and_time(Utc::now().time())?
-                .with_timezone(self.tz)
-                .time()
+            Utc::now().with_timezone(self.tz).time()
         };
 
         let dt = input.replace(", ", " ").replace(". ", " ");
@@ -587,11 +571,7 @@ where
         let time = if let Some(v) = self.default_time {
             v
         } else {
-            Utc::now()
-                .date()
-                .and_time(Utc::now().time())?
-                .with_timezone(self.tz)
-                .time()
+            Utc::now().with_timezone(self.tz).time()
         };
 
         NaiveDate::parse_from_str(input, "%d %B %y")
@@ -660,11 +640,7 @@ where
         let time = if let Some(v) = self.default_time {
             v
         } else {
-            Utc::now()
-                .date()
-                .and_time(Utc::now().time())?
-                .with_timezone(self.tz)
-                .time()
+            Utc::now().with_timezone(self.tz).time()
         };
 
         NaiveDate::parse_from_str(input, "%m/%d/%y")
@@ -720,11 +696,7 @@ where
         let time = if let Some(v) = self.default_time {
             v
         } else {
-            Utc::now()
-                .date()
-                .and_time(Utc::now().time())?
-                .with_timezone(self.tz)
-                .time()
+            Utc::now().with_timezone(self.tz).time()
         };
 
         NaiveDate::parse_from_str(input, "%Y/%m/%d")
@@ -754,11 +726,7 @@ where
         let time = if let Some(v) = self.default_time {
             v
         } else {
-            Utc::now()
-                .date()
-                .and_time(Utc::now().time())?
-                .with_timezone(self.tz)
-                .time()
+            Utc::now().with_timezone(self.tz).time()
         };
 
         NaiveDate::parse_from_str(input, "%m.%d.%y")
@@ -824,11 +792,7 @@ where
         let time = if let Some(v) = self.default_time {
             v
         } else {
-            Utc::now()
-                .date()
-                .and_time(Utc::now().time())?
-                .with_timezone(self.tz)
-                .time()
+            Utc::now().with_timezone(self.tz).time()
         };
 
         NaiveDate::parse_from_str(input, "%Y年%m月%d日")

--- a/dateparser/src/datetime.rs
+++ b/dateparser/src/datetime.rs
@@ -302,7 +302,7 @@ where
                     Ok(offset) => {
                         // set time to use
                         let time = if let Some(v) = self.default_time {
-                            Utc::now().date().and_time(v)?.with_timezone(&offset).time()
+                            v
                         } else {
                             Utc::now().with_timezone(&offset).time()
                         };
@@ -1059,7 +1059,7 @@ mod tests {
 
     #[test]
     fn ymd_z() {
-        let parse = Parse::new(&Utc, Some(Utc::now().time()));
+        let parse = Parse::new(&Utc, None);
         let now_at_pst = Utc::now().with_timezone(&FixedOffset::west(8 * 3600));
         let now_at_cst = Utc::now().with_timezone(&FixedOffset::east(8 * 3600));
 

--- a/dateparser/src/lib.rs
+++ b/dateparser/src/lib.rs
@@ -871,7 +871,7 @@ mod tests {
         }
 
         // test us_edt at 23:59:59 - UTC will be one day ahead
-        let us_edt_before_midnight_as_utc = Utc.ymd(2023, 4, 22).and_hms(03, 59, 59);
+        let us_edt_before_midnight_as_utc = Utc.ymd(2023, 4, 22).and_hms(3, 59, 59);
         for &(test, input) in edt_test_cases.iter() {
             assert_eq!(
                 super::parse_with(input, us_edt, before_midnight_naive).unwrap(),
@@ -914,7 +914,7 @@ mod tests {
         }
 
         // test us_est at 23:59:59 - UTC will be one day ahead
-        let us_est_before_midnight_as_utc = Utc.ymd(2023, 12, 22).and_hms(04, 59, 59);
+        let us_est_before_midnight_as_utc = Utc.ymd(2023, 12, 22).and_hms(4, 59, 59);
         for &(test, input) in est_test_cases.iter() {
             assert_eq!(
                 super::parse_with(input, us_est, before_midnight_naive).unwrap(),

--- a/dateparser/src/lib.rs
+++ b/dateparser/src/lib.rs
@@ -828,4 +828,98 @@ mod tests {
             };
         }
     }
+
+    #[test]
+    fn parse_with() {
+        // Two sets of tests - one for EDT and one for EST
+        // TODO: add eastern hemisphere set of timezones?
+
+        // Both will use these naive times
+        let midnight_naive = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+        let before_midnight_naive = NaiveTime::from_hms_opt(23, 59, 59).unwrap();
+
+        // EDT
+        // Eastern Daylight Time is from (as of 2023) 2nd Sun in Mar to 1st Sun in Nov
+        // It is UTC -4
+        let us_edt = &FixedOffset::west(4 * 3600);
+
+        let edt_test_cases = vec![
+            ("ymd", "2023-04-21"),
+            // ("ymd_z", "2023-04-21 EDT"), // not sure about this one
+            ("month_ymd", "2023-Apr-21"),
+            ("month_mdy", "April 21, 2023"),
+            ("month_dmy", "21 April 2023"),
+            ("slash_mdy", "04/21/23"),
+            ("slash_ymd", "2023/4/21"),
+            ("dot_mdy_or_ymd", "2023.04.21"),
+            // (
+            //     "chinese_ymd",
+            //     "2014年04月08日",
+            //     Utc.ymd(2014, 4, 8).and_time(Utc::now().time()).unwrap(),
+            // ),
+        ];
+
+        // test us_edt at midnight
+        let us_edt_midnight_as_utc = Utc.ymd(2023, 4, 21).and_hms(4, 0, 0);
+
+        for &(test, input) in edt_test_cases.iter() {
+            assert_eq!(
+                super::parse_with(input, us_edt, midnight_naive).unwrap(),
+                us_edt_midnight_as_utc,
+                "parse_with/{test}/{input}",
+            )
+        }
+
+        // test us_edt at 23:59:59 - UTC will be one day ahead
+        let us_edt_before_midnight_as_utc = Utc.ymd(2023, 4, 22).and_hms(03, 59, 59);
+        for &(test, input) in edt_test_cases.iter() {
+            assert_eq!(
+                super::parse_with(input, us_edt, before_midnight_naive).unwrap(),
+                us_edt_before_midnight_as_utc,
+                "parse_with/{test}/{input}",
+            )
+        }
+
+        // EST
+        // Eastern Standard Time is from (as of 2023) 1st Sun in Nov to 2nd Sun in Mar
+        // It is UTC -5
+        let us_est = &FixedOffset::west(5 * 3600);
+
+        let est_test_cases = vec![
+            ("ymd", "2023-12-21"),
+            // ("ymd_z", "2023-12-21 EST"), // not sure about this one
+            ("month_ymd", "2023-Dec-21"),
+            ("month_mdy", "December 21, 2023"),
+            ("month_dmy", "21 December 2023"),
+            ("slash_mdy", "12/21/23"),
+            ("slash_ymd", "2023/12/21"),
+            ("dot_mdy_or_ymd", "2023.12.21"),
+            // (
+            //     "chinese_ymd",
+            //     "2014年04月08日",
+            //     Utc.ymd(2014, 4, 8).and_time(Utc::now().time()).unwrap(),
+            // ),
+        ];
+
+        // test us_est at midnight
+        let us_est_midnight_as_utc = Utc.ymd(2023, 12, 21).and_hms(5, 0, 0);
+
+        for &(test, input) in est_test_cases.iter() {
+            assert_eq!(
+                super::parse_with(input, us_est, midnight_naive).unwrap(),
+                us_est_midnight_as_utc,
+                "parse_with/{test}/{input}",
+            )
+        }
+
+        // test us_est at 23:59:59 - UTC will be one day ahead
+        let us_est_before_midnight_as_utc = Utc.ymd(2023, 12, 22).and_hms(04, 59, 59);
+        for &(test, input) in est_test_cases.iter() {
+            assert_eq!(
+                super::parse_with(input, us_est, before_midnight_naive).unwrap(),
+                us_est_before_midnight_as_utc,
+                "parse_with/{test}/{input}",
+            )
+        }
+    }
 }

--- a/dateparser/src/lib.rs
+++ b/dateparser/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! A rust library for parsing date strings in commonly used formats. Parsed date will be returned
 //! as `chrono`'s `DateTime<Utc>`.
 //!
@@ -194,14 +195,13 @@
 /// use std::error::Error;
 ///
 /// fn main() -> Result<(), Box<dyn Error>> {
-///     let utc_now_time = Utc::now().time();
-///     let parse_with_local = Parse::new(&Local, utc_now_time);
+///     let parse_with_local = Parse::new(&Local, None);
 ///     assert_eq!(
 ///         parse_with_local.parse("2021-06-05 06:19 PM")?,
 ///         Local.ymd(2021, 6, 5).and_hms(18, 19, 0).with_timezone(&Utc),
 ///     );
 ///
-///     let parse_with_utc = Parse::new(&Utc, utc_now_time);
+///     let parse_with_utc = Parse::new(&Utc, None);
 ///     assert_eq!(
 ///         parse_with_utc.parse("2021-06-05 06:19 PM")?,
 ///         Utc.ymd(2021, 6, 5).and_hms(18, 19, 0),
@@ -283,7 +283,7 @@ impl std::str::FromStr for DateTimeUtc {
 /// );
 /// ```
 pub fn parse(input: &str) -> Result<DateTime<Utc>> {
-    Parse::new(&Local, Utc::now().time()).parse(input)
+    Parse::new(&Local, None).parse(input)
 }
 
 /// Similar to [`parse()`], this function takes a datetime string and a custom [`chrono::TimeZone`],
@@ -314,7 +314,7 @@ pub fn parse(input: &str) -> Result<DateTime<Utc>> {
 /// );
 /// ```
 pub fn parse_with_timezone<Tz2: TimeZone>(input: &str, tz: &Tz2) -> Result<DateTime<Utc>> {
-    Parse::new(tz, Utc::now().time()).parse(input)
+    Parse::new(tz, None).parse(input)
 }
 
 /// Similar to [`parse()`] and [`parse_with_timezone()`], this function takes a datetime string, a
@@ -326,34 +326,41 @@ pub fn parse_with_timezone<Tz2: TimeZone>(input: &str, tz: &Tz2) -> Result<DateT
 /// use dateparser::parse_with;
 /// use chrono::prelude::*;
 ///
-/// let utc_now_time = Utc::now().time();
-/// let local_now_time = Local::now().time();
-/// let midnight = NaiveTime::from_hms(0, 0, 0);
+/// let utc_now = Utc::now().time().trunc_subsecs(0);
+/// let local_now = Local::now().time().trunc_subsecs(0);
+/// let midnight_naive = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+/// let before_midnight_naive = NaiveTime::from_hms_opt(23, 59, 59).unwrap();
 ///
-/// let parsed_in_local_with_utc_now_time = parse_with("2021-10-09", &Local, utc_now_time);
-/// let parsed_in_local_with_utc_midnight = parse_with("2021-10-09", &Local, midnight);
-/// let parsed_in_utc_with_utc_now_time = parse_with("2021-10-09", &Utc, utc_now_time);
-/// let parsed_in_utc_with_utc_midnight = parse_with("2021-10-09", &Utc, midnight);
+/// let parsed_with_local_now = parse_with("2021-10-09", &Local, local_now);
+/// let parsed_with_local_midnight = parse_with("2021-10-09", &Local, midnight_naive);
+/// let parsed_with_local_before_midnight = parse_with("2021-10-09", &Local, before_midnight_naive);
+/// let parsed_with_utc_now = parse_with("2021-10-09", &Utc, utc_now);
+/// let parsed_with_utc_midnight = parse_with("2021-10-09", &Utc, midnight_naive);
 ///
 /// assert_eq!(
-///     parsed_in_local_with_utc_now_time.unwrap().trunc_subsecs(0),
-///     Local.ymd(2021, 10, 9).and_time(local_now_time).unwrap().with_timezone(&Utc).trunc_subsecs(0),
-///     "parsed_in_local_with_utc_now_time"
+///     parsed_with_local_now.unwrap(),
+///     Local.ymd(2021, 10, 9).and_time(local_now).unwrap().with_timezone(&Utc),
+///     "parsed_with_local_now"
 /// );
 /// assert_eq!(
-///     parsed_in_local_with_utc_midnight.unwrap().trunc_subsecs(0),
-///     Local.ymd(2021, 10, 9).and_time(local_now_time).unwrap().with_timezone(&Utc).date().and_hms(0, 0, 0),
-///     "parsed_in_local_with_utc_midnight"
+///     parsed_with_local_midnight.unwrap(),
+///     Local.ymd(2021, 10, 9).and_time(midnight_naive).unwrap().with_timezone(&Utc),
+///     "parsed_with_local_midnight"
 /// );
 /// assert_eq!(
-///     parsed_in_utc_with_utc_now_time.unwrap(),
-///     Utc.ymd(2021, 10, 9).and_time(utc_now_time).unwrap(),
-///     "parsed_in_utc_with_utc_now_time"
+///     parsed_with_local_before_midnight.unwrap(),
+///     Local.ymd(2021, 10, 9).and_time(before_midnight_naive).unwrap().with_timezone(&Utc),
+///     "parsed_with_local_before_midnight"
 /// );
 /// assert_eq!(
-///     parsed_in_utc_with_utc_midnight.unwrap().trunc_subsecs(0),
+///     parsed_with_utc_now.unwrap(),
+///     Utc.ymd(2021, 10, 9).and_time(utc_now).unwrap(),
+///     "parsed_with_utc_now"
+/// );
+/// assert_eq!(
+///     parsed_with_utc_midnight.unwrap(),
 ///     Utc.ymd(2021, 10, 9).and_hms(0, 0, 0),
-///     "parsed_in_utc_with_utc_midnight"
+///     "parsed_with_utc_midnight"
 /// );
 /// ```
 pub fn parse_with<Tz2: TimeZone>(
@@ -361,7 +368,7 @@ pub fn parse_with<Tz2: TimeZone>(
     tz: &Tz2,
     default_time: NaiveTime,
 ) -> Result<DateTime<Utc>> {
-    Parse::new(tz, default_time).parse(input)
+    Parse::new(tz, Some(default_time)).parse(input)
 }
 
 #[cfg(test)]
@@ -829,23 +836,20 @@ mod tests {
         }
     }
 
-    #[test]
-    fn parse_with() {
-        // Two sets of tests - one for EDT and one for EST
-        // TODO: add eastern hemisphere set of timezones?
+    // test parse_with() with various timezones and times
 
-        // Both will use these naive times
+    #[test]
+    fn parse_with_edt() {
+        // Eastern Daylight Time (EDT) is from (as of 2023) 2nd Sun in Mar to 1st Sun in Nov
+        // It is UTC -4
+
         let midnight_naive = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
         let before_midnight_naive = NaiveTime::from_hms_opt(23, 59, 59).unwrap();
-
-        // EDT
-        // Eastern Daylight Time is from (as of 2023) 2nd Sun in Mar to 1st Sun in Nov
-        // It is UTC -4
-        let us_edt = &FixedOffset::west(4 * 3600);
+        let us_edt = &FixedOffset::west_opt(4 * 3600).unwrap();
 
         let edt_test_cases = vec![
             ("ymd", "2023-04-21"),
-            // ("ymd_z", "2023-04-21 EDT"), // not sure about this one
+            // ("ymd_z", "2023-04-21 EDT"), // FIXME not sure about this one
             ("month_ymd", "2023-Apr-21"),
             ("month_mdy", "April 21, 2023"),
             ("month_dmy", "21 April 2023"),
@@ -879,15 +883,20 @@ mod tests {
                 "parse_with/{test}/{input}",
             )
         }
+    }
 
-        // EST
-        // Eastern Standard Time is from (as of 2023) 1st Sun in Nov to 2nd Sun in Mar
+    #[test]
+    fn parse_with_est() {
+        // Eastern Standard Time (EST) is from (as of 2023) 1st Sun in Nov to 2nd Sun in Mar
         // It is UTC -5
+
+        let midnight_naive = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+        let before_midnight_naive = NaiveTime::from_hms_opt(23, 59, 59).unwrap();
         let us_est = &FixedOffset::west(5 * 3600);
 
         let est_test_cases = vec![
             ("ymd", "2023-12-21"),
-            // ("ymd_z", "2023-12-21 EST"), // not sure about this one
+            // ("ymd_z", "2023-12-21 EST"), // FIXME not sure about this one
             ("month_ymd", "2023-Dec-21"),
             ("month_mdy", "December 21, 2023"),
             ("month_dmy", "21 December 2023"),
@@ -918,6 +927,94 @@ mod tests {
             assert_eq!(
                 super::parse_with(input, us_est, before_midnight_naive).unwrap(),
                 us_est_before_midnight_as_utc,
+                "parse_with/{test}/{input}",
+            )
+        }
+    }
+
+    #[test]
+    fn parse_with_utc() {
+        let midnight_naive = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+        let before_midnight_naive = NaiveTime::from_hms_opt(23, 59, 59).unwrap();
+        let utc_test_cases = vec![
+            ("ymd", "2023-12-21"),
+            // ("ymd_z", "2023-12-21 EST"), // FIXME not sure about this one
+            ("month_ymd", "2023-Dec-21"),
+            ("month_mdy", "December 21, 2023"),
+            ("month_dmy", "21 December 2023"),
+            ("slash_mdy", "12/21/23"),
+            ("slash_ymd", "2023/12/21"),
+            ("dot_mdy_or_ymd", "2023.12.21"),
+            // (
+            //     "chinese_ymd",
+            //     "2014年04月08日",
+            //     Utc.ymd(2014, 4, 8).and_time(Utc::now().time()).unwrap(),
+            // ),
+        ];
+
+        // test utc at midnight
+        let utc_midnight = Utc.ymd(2023, 12, 21).and_hms(0, 0, 0);
+
+        for &(test, input) in utc_test_cases.iter() {
+            assert_eq!(
+                super::parse_with(input, &Utc, midnight_naive).unwrap(),
+                utc_midnight,
+                "parse_with/{test}/{input}",
+            )
+        }
+
+        // test utc at 23:59:59
+        let utc_before_midnight = Utc.ymd(2023, 12, 21).and_hms(23, 59, 59);
+        for &(test, input) in utc_test_cases.iter() {
+            assert_eq!(
+                super::parse_with(input, &Utc, before_midnight_naive).unwrap(),
+                utc_before_midnight,
+                "parse_with/{test}/{input}",
+            )
+        }
+    }
+
+    #[test]
+    fn parse_with_local() {
+        let midnight_naive = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+        let before_midnight_naive = NaiveTime::from_hms_opt(23, 59, 59).unwrap();
+        let local_test_cases = vec![
+            ("ymd", "2023-12-21"),
+            // ("ymd_z", "2023-12-21 EST"), // FIXME not sure about this one
+            ("month_ymd", "2023-Dec-21"),
+            ("month_mdy", "December 21, 2023"),
+            ("month_dmy", "21 December 2023"),
+            ("slash_mdy", "12/21/23"),
+            ("slash_ymd", "2023/12/21"),
+            ("dot_mdy_or_ymd", "2023.12.21"),
+            // (
+            //     "chinese_ymd",
+            //     "2014年04月08日",
+            //     Utc.ymd(2014, 4, 8).and_time(Utc::now().time()).unwrap(),
+            // ),
+        ];
+
+        // test local at midnight
+        let local_midnight_as_utc = Local.ymd(2023, 12, 21).and_hms(0, 0, 0).with_timezone(&Utc);
+
+        for &(test, input) in local_test_cases.iter() {
+            assert_eq!(
+                super::parse_with(input, &Local, midnight_naive).unwrap(),
+                local_midnight_as_utc,
+                "parse_with/{test}/{input}",
+            )
+        }
+
+        // test local at 23:59:59
+        let local_before_midnight_as_utc = Local
+            .ymd(2023, 12, 21)
+            .and_hms(23, 59, 59)
+            .with_timezone(&Utc);
+
+        for &(test, input) in local_test_cases.iter() {
+            assert_eq!(
+                super::parse_with(input, &Local, before_midnight_naive).unwrap(),
+                local_before_midnight_as_utc,
                 "parse_with/{test}/{input}",
             )
         }

--- a/dateparser/src/lib.rs
+++ b/dateparser/src/lib.rs
@@ -849,18 +849,14 @@ mod tests {
 
         let edt_test_cases = vec![
             ("ymd", "2023-04-21"),
-            // ("ymd_z", "2023-04-21 EDT"), // FIXME not sure about this one
+            ("ymd_z", "2023-04-21 EDT"),
             ("month_ymd", "2023-Apr-21"),
             ("month_mdy", "April 21, 2023"),
             ("month_dmy", "21 April 2023"),
             ("slash_mdy", "04/21/23"),
             ("slash_ymd", "2023/4/21"),
             ("dot_mdy_or_ymd", "2023.04.21"),
-            // (
-            //     "chinese_ymd",
-            //     "2014年04月08日",
-            //     Utc.ymd(2014, 4, 8).and_time(Utc::now().time()).unwrap(),
-            // ),
+            ("chinese_ymd", "2023年04月21日"),
         ];
 
         // test us_edt at midnight
@@ -896,18 +892,14 @@ mod tests {
 
         let est_test_cases = vec![
             ("ymd", "2023-12-21"),
-            // ("ymd_z", "2023-12-21 EST"), // FIXME not sure about this one
+            ("ymd_z", "2023-12-21 EST"),
             ("month_ymd", "2023-Dec-21"),
             ("month_mdy", "December 21, 2023"),
             ("month_dmy", "21 December 2023"),
             ("slash_mdy", "12/21/23"),
             ("slash_ymd", "2023/12/21"),
             ("dot_mdy_or_ymd", "2023.12.21"),
-            // (
-            //     "chinese_ymd",
-            //     "2014年04月08日",
-            //     Utc.ymd(2014, 4, 8).and_time(Utc::now().time()).unwrap(),
-            // ),
+            ("chinese_ymd", "2023年12月21日"),
         ];
 
         // test us_est at midnight
@@ -938,20 +930,15 @@ mod tests {
         let before_midnight_naive = NaiveTime::from_hms_opt(23, 59, 59).unwrap();
         let utc_test_cases = vec![
             ("ymd", "2023-12-21"),
-            // ("ymd_z", "2023-12-21 EST"), // FIXME not sure about this one
+            ("ymd_z", "2023-12-21 UTC"),
             ("month_ymd", "2023-Dec-21"),
             ("month_mdy", "December 21, 2023"),
             ("month_dmy", "21 December 2023"),
             ("slash_mdy", "12/21/23"),
             ("slash_ymd", "2023/12/21"),
             ("dot_mdy_or_ymd", "2023.12.21"),
-            // (
-            //     "chinese_ymd",
-            //     "2014年04月08日",
-            //     Utc.ymd(2014, 4, 8).and_time(Utc::now().time()).unwrap(),
-            // ),
+            ("chinese_ymd", "2023年12月21日"),
         ];
-
         // test utc at midnight
         let utc_midnight = Utc.ymd(2023, 12, 21).and_hms(0, 0, 0);
 
@@ -980,18 +967,13 @@ mod tests {
         let before_midnight_naive = NaiveTime::from_hms_opt(23, 59, 59).unwrap();
         let local_test_cases = vec![
             ("ymd", "2023-12-21"),
-            // ("ymd_z", "2023-12-21 EST"), // FIXME not sure about this one
             ("month_ymd", "2023-Dec-21"),
             ("month_mdy", "December 21, 2023"),
             ("month_dmy", "21 December 2023"),
             ("slash_mdy", "12/21/23"),
             ("slash_ymd", "2023/12/21"),
             ("dot_mdy_or_ymd", "2023.12.21"),
-            // (
-            //     "chinese_ymd",
-            //     "2014年04月08日",
-            //     Utc.ymd(2014, 4, 8).and_time(Utc::now().time()).unwrap(),
-            // ),
+            ("chinese_ymd", "2023年12月21日"),
         ];
 
         // test local at midnight

--- a/dateparser/src/timezone.rs
+++ b/dateparser/src/timezone.rs
@@ -20,7 +20,7 @@ fn parse_offset_2822(s: &str) -> Result<i32> {
     let upto = s
         .as_bytes()
         .iter()
-        .position(|&c| !matches!(c, b'a'..=b'z' | b'A'..=b'Z'))
+        .position(|&c| !c.is_ascii_alphabetic())
         .unwrap_or(s.len());
     if upto > 0 {
         let name = &s[..upto];


### PR DESCRIPTION
I have been using the `dateparser` library in developing a project of mine (https://codeberg.org/kdwarn/ts-cli) and found a bug with the `parse_with` function. As detailed in an issue there (https://codeberg.org/kdwarn/ts-cli/issues/18), it wasn't converting correctly to UTC. Essentially, the `default_time` parameter to `Parse::new` needs to be different if using `parse` and `parse_with_timezone` or if using `parse_with`. The solution I came up with was to change `Parse` struct's field `default_time` to an `Option<NaiveTime>` rather than a `NaiveTime`, and then in the various functions either use the provided `default_time` if given or create one at that time. Given this, I imagine you'll want to do a version bump.

In the existing code, there were only doctests that covered `parse_with` (no separate unit tests), and at least one was failing. I wrote out what I think to be a fairly comprehensive set of units tests, and both they and the doctests are now passing. I had to modify a lot of tests to account for changing `default_time` from `NaiveTime` to `Option<NativeTime>`.

Note that I also bumped to the new 2021 edition of Rust, and there seems to be no issues with that.

Also, I explicitly bumped to 0.4.24 of `chrono`, and then turned off deprecation warnings, as there are many. I figure they can be addressed separately after this.